### PR TITLE
Light sensor: drop ratiometric ref-voltage calibration

### DIFF
--- a/lib/utils/Utils.cpp
+++ b/lib/utils/Utils.cpp
@@ -95,22 +95,18 @@ float getWindDirection(float voltage, float maxVoltage) {
 }
 
 // ##################### everything for light sensor ###############################3
-float getSolarRadiation(Adafruit_ADS1115& ads, uint8_t signalChannel, uint8_t refChannel) {
+float getSolarRadiation(Adafruit_ADS1115& ads, uint8_t signalChannel) {
     // 1. Read the signal from the solar sensor
     int16_t rawSignal = ads.readADC_SingleEnded(signalChannel);
-    // 2. Read the reference voltage (excitation voltage)
-    int16_t rawRef = ads.readADC_SingleEnded(refChannel);
 
-    // 3. Safety: Handle negative noise
+    // 2. Safety: Handle negative noise
     if (rawSignal < 0) rawSignal = 0;
-    
-    // 4. Prevent division by zero if reference is missing/disconnected
-    if (rawRef <= 0) return 0.0; 
 
-    // 5. Ratiometric Calculation: (Signal / Reference) * 1800
-    // Note: Since both use the same Gain, we can use raw ADC steps 
-    // because the 0.125mV multiplier would just cancel itself out.
-    float solarRadiation = ((float)rawSignal / (float)rawRef) * 1800.0;
+    // 3. Raw ADC steps to millivolts (0.125mV per step at this gain)
+    float signalMv = (float)rawSignal * 0.125f;
+
+    // 4. Fixed scale: sensor outputs 1.67mV per W/m^2
+    float solarRadiation = signalMv / 1.67f;
 
     return solarRadiation;
 }

--- a/lib/utils/Utils.h
+++ b/lib/utils/Utils.h
@@ -19,7 +19,7 @@ void wind_Counter();
 float getWindDirection(float voltage, float maxVoltage);
 
 // ##################### everything for the light sensor ###############################3
-float getSolarRadiation(Adafruit_ADS1115& ads, uint8_t signalChannel, uint8_t refChannel);
+float getSolarRadiation(Adafruit_ADS1115& ads, uint8_t signalChannel);
 
 // int readFanSpeed();
 // void setExternalFanSpeed(Adafruit_PWMServoDriver& pwmBoard, int pwm_channel, int percent);

--- a/src/cubecell_battery_main.cpp
+++ b/src/cubecell_battery_main.cpp
@@ -295,7 +295,7 @@ void loop() {
             float degrees = getWindDirection(windVolts, refVolts);
 
             //light intensity
-            float solarRadiation = getSolarRadiation(ads, adcLightIntensityChannel, 2);
+            float solarRadiation = getSolarRadiation(ads, adcLightIntensityChannel);
             
             //the sht sensor
             sht.read(); 


### PR DESCRIPTION
## Summary
- `getSolarRadiation()` no longer divides raw signal by the shared reference-voltage ADC channel
- Converts raw ADC counts to mV (0.125mV/step) and divides by fixed 1.67 mV per W/m^2 instead
- Updated call site (2 args instead of 3) and header signature

Closes #92.

## Test plan
- [ ] Flash to CubeCell and confirm light_intensity readings look sane vs known light levels
- [ ] Confirm no build errors on CubeCell-AB01 env

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01BcPMT2SYY9vxAjUQBGvYvN